### PR TITLE
Added z-score calculation of non-permuted pcr

### DIFF
--- a/.profiles/icb/config.yaml
+++ b/.profiles/icb/config.yaml
@@ -10,11 +10,11 @@ cluster:
     --output=logs/%j-{rule}.out
     --parsable
 default-resources:
-  - partition=cpu_p
-  - qos=cpu_normal
-  - gpu=0
-  - mem_mb=90000
-  - disk_mb=20000
+  - partition=gpu_p
+  - qos=gpu_normal
+  - gpu=1
+  - mem_mb=240000
+#  - disk_mb=20000
 restart-times: 0
 max-jobs-per-second: 10
 max-status-checks-per-second: 1

--- a/.profiles/icb/config.yaml
+++ b/.profiles/icb/config.yaml
@@ -10,11 +10,10 @@ cluster:
     --output=logs/%j-{rule}.out
     --parsable
 default-resources:
-  - partition=gpu_p
-  - qos=gpu_normal
-  - gpu=1
-  - mem_mb=240000
-#  - disk_mb=20000
+  - partition=cpu_p
+  - qos=cpu_normal
+  - gpu=0
+  - mem_mb=90000
 restart-times: 0
 max-jobs-per-second: 10
 max-status-checks-per-second: 1

--- a/workflow/batch_analysis/rules/batch_pcr.smk
+++ b/workflow/batch_analysis/rules/batch_pcr.smk
@@ -7,7 +7,7 @@ checkpoint determine_covariates:
         covariates=lambda wildcards: mcfg.get_from_parameters(wildcards, 'covariates', default=[]),
         permute_covariates=lambda wildcards: mcfg.get_from_parameters(wildcards, 'permute_covariates', default=None),
         sample_key=lambda wildcards: mcfg.get_from_parameters(wildcards, 'sample', check_query_keys=False),
-        # n_permute=lambda wildcards: mcfg.get_from_parameters(wildcards, 'n_permutations', default=10),
+        n_permute=lambda wildcards: mcfg.get_from_parameters(wildcards, 'n_permutations', default=10),
     conda:
         get_env(config, 'scanpy')
     script:
@@ -37,12 +37,12 @@ rule batch_pcr:
     output:
         tsv=mcfg.out_dir / paramspace.wildcard_pattern / 'batch_pcr' / '{covariate}.tsv',
     params:
-        n_permute=lambda wildcards: mcfg.get_from_parameters(wildcards, 'n_permutations', default=10, check_query_keys=False),
+        n_permute=lambda wildcards: mcfg.get_from_parameters(wildcards, 'n_permutations', check_query_keys=False),
         sample_key=lambda wildcards: mcfg.get_from_parameters(wildcards, 'sample', check_query_keys=False),
     conda:
         get_env(config, 'scib')
     threads:
-        lambda wildcards: max(1, min(10, mcfg.get_from_parameters(wildcards, 'n_permutations', default=10, check_query_keys=False)))
+        lambda wildcards: max(1, min(10, mcfg.get_from_parameters(wildcards, 'n_permutations', check_query_keys=False)))
     resources:
         partition=mcfg.get_resource(profile='cpu',resource_key='partition'),
         qos=mcfg.get_resource(profile='cpu',resource_key='qos'),

--- a/workflow/batch_analysis/rules/batch_pcr.smk
+++ b/workflow/batch_analysis/rules/batch_pcr.smk
@@ -59,7 +59,7 @@ rule collect:
     run:
         dfs = [pd.read_table(file) for file in input.tsv]
         if len(dfs) == 0:
-            df = pd.DataFrame(columns=['covariate', 'pcr', 'permuted', 'n_covariates'])
+            df = pd.DataFrame(columns=['covariate', 'pcr', 'permuted', 'n_covariates', 'non_perm_z_score'])
         else:
             df = pd.concat(dfs, ignore_index=True)
         df.to_csv(output.tsv, sep='\t', index=False)

--- a/workflow/batch_analysis/scripts/batch_pcr.py
+++ b/workflow/batch_analysis/scripts/batch_pcr.py
@@ -96,7 +96,7 @@ with ProcessPoolExecutor(max_workers=n_threads) as pool:
     for future in as_completed(futures):
         completed_futures += 1
         pcr_scores.append(future.result())
-        print(f'{completed_futures}/{total_futures} covariates completed', flush=True)
+        print(f'{completed_futures}/{total_futures} completed for {covariate}', flush=True)
 
 # Set permuted score when covariate is the same as the group variable
 if covariate == sample_key:

--- a/workflow/batch_analysis/scripts/batch_pcr.py
+++ b/workflow/batch_analysis/scripts/batch_pcr.py
@@ -115,11 +115,13 @@ df = pd.DataFrame.from_records(
     columns=['covariate', 'permuted', 'pcr'],
 )
 
-covariate = df['covariate'].str.split('-', expand=True)[0].astype('category')
+# calculate summary stats
+df['covariate'] = df['covariate'].str.split('-', expand=True)[0].astype('category')
+df['n_covariates'] = n_covariate
+df['perm_mean'] = df.loc[df['permuted'], 'pcr'].mean()
+df['perm_std'] = df.loc[df['permuted'], 'pcr'].std()
+df['z_score'] = (df['pcr'] - df['perm_mean']) / df['perm_std']
 
-df['n_covariates'] = f'n={n_covariate}'
-df['covariate'] = covariate
-df['non_perm_z_score'] = np.nan # init z-score column with NaNs
 
 if (~df['permuted']).sum() != 1:
     print(

--- a/workflow/batch_analysis/scripts/batch_pcr.py
+++ b/workflow/batch_analysis/scripts/batch_pcr.py
@@ -121,28 +121,8 @@ df['n_covariates'] = n_covariate
 df['perm_mean'] = df.loc[df['permuted'], 'pcr'].mean()
 df['perm_std'] = df.loc[df['permuted'], 'pcr'].std()
 df['z_score'] = (df['pcr'] - df['perm_mean']) / df['perm_std']
+df['signif'] = df['z_score'] > 1.5
+df['p-val'] = df.loc[df['permuted'], 'signif'].sum() / n_permute
 
-
-if (~df['permuted']).sum() != 1:
-    print(
-        f'Warning: No non-permuted entries found for covariate: {covariate}.'
-        f'Result will be NaN.'
-    )
-else:
-    perm_scores_mean = np.mean(df.loc[df['permuted'], 'pcr'])
-    perm_scores_std = np.std(df.loc[df['permuted'], 'pcr'])
-
-    if np.isnan(perm_scores_mean) or np.isnan(perm_scores_std) or \
-        perm_scores_std == 0:
-        print(
-            'Warning: Invalid mean or standard deviation. Mean is NaN, or '
-            'standard deviation is zero. Result will be NaN.'
-        )
-    else:
-        non_perm_z_score = (
-            (df.loc[~df['permuted'], 'pcr'] - perm_scores_mean) /
-            perm_scores_std
-        )
-        df['non_perm_z_score'] = f'z={non_perm_z_score.iloc[0].round(2)}'
-
+print(df, flush=True)
 df.to_csv(output_file, sep='\t', index=False)

--- a/workflow/batch_analysis/scripts/determine_covariates.py
+++ b/workflow/batch_analysis/scripts/determine_covariates.py
@@ -15,7 +15,7 @@ covariates = snakemake.params.get('covariates', [])
 perm_covariates = snakemake.params.get('permute_covariates')
 if perm_covariates is None:
     perm_covariates = covariates
-n_perms = snakemake.params.get('n_perms')
+n_perms = snakemake.params.get('n_permute')
 
 logging.info(f'Read {input_file}...')
 if input_file.endswith('.h5ad'):

--- a/workflow/batch_analysis/scripts/plot.py
+++ b/workflow/batch_analysis/scripts/plot.py
@@ -36,26 +36,40 @@ g = sns.barplot(
     hue='permuted',
     errorbar='sd',
     dodge=True,
-    errwidth=1,
+    err_kws={'linewidth': 1},
     capsize=.1,
 )
-g.set(title=f'PCR of covariates for: {dataset} {file_id}')
-grouped_by_covariate = df.groupby('covariate', sort=False)
-bar_labels = grouped_by_covariate['pcr'].first().round(2).astype(str).str.cat(
-    grouped_by_covariate['n_covariates'].first(),
-    grouped_by_covariate['non_perm_z_score'].first(),
-    sep=', '
-)
-g.bar_label(
-    g.containers[0],
-    labels=bar_labels,
-    padding=10
-)
+g.set(title=f'Principal Component Regression scores of covariates for: {dataset} {file_id}')
+
+def round_values(x, prefix='', n_digits=3):
+    if x < 10 ** (-n_digits):
+        f'{prefix}{x:.2e}'
+    elif pd.notna(x):
+        return f'{prefix}{x:.{n_digits}f}'
+    return ''
+
+df['pcr_string'] = df['pcr'].apply(round_values)
+df['n_covariates'] = df['n_covariates'].apply(lambda x: f'n={x}')
+df['signif'] = df['z_score'].apply(lambda x: '**' if x > 3 else '*' if x > 1.5 else '')
+df['z_score'] = df['z_score'].apply(round_values, prefix='z=', n_digits=2)
+
+# create bar labels for covariate
+covariate_bar_labels = df.groupby('covariate', sort=False).first()[
+    ['pcr_string', 'z_score', 'n_covariates', 'signif']
+].astype(str).agg(lambda x: ', '.join([s for s in x if s]), axis=1)
+print(covariate_bar_labels)
+g.bar_label(g.containers[0], labels=covariate_bar_labels, padding=10)
+
+# create bar labels for permuted covariates
+if len(g.containers) > 1:
+    perm_bar_labels = df.groupby('covariate', sort=False).first()['perm_std'].apply(round_values, prefix='std=')
+    g.bar_label(g.containers[1], labels=perm_bar_labels, padding=25)
+
 plt.xticks(rotation=90)
 sns.despine()
 
 logger.info('Save barplot...')
-plt.savefig(output_bar, bbox_inches='tight',dpi=300)
+plt.savefig(output_bar, bbox_inches='tight', dpi=300)
 
 logging.info('Violin plot...')
 plt.clf()

--- a/workflow/batch_analysis/scripts/plot.py
+++ b/workflow/batch_analysis/scripts/plot.py
@@ -43,6 +43,7 @@ g.set(title=f'PCR of covariates for: {dataset} {file_id}')
 grouped_by_covariate = df.groupby('covariate', sort=False)
 bar_labels = grouped_by_covariate['pcr'].first().round(2).astype(str).str.cat(
     grouped_by_covariate['n_covariates'].first(),
+    grouped_by_covariate['non_perm_z_score'].first(),
     sep=', '
 )
 g.bar_label(


### PR DESCRIPTION
Added for the workflow "batch_covariate_analysis":

- An additional column to the output file "non_perm_z_score" which contains the z-score of the non-permuted pcr
- This column is now also considered in the collect rule of batch_pcr.smk
- Lastly, the calculated z-score is plotted as the annotation of the barplot (structure: <pcr>, <n_covariates>, <non_perm_z_score>)